### PR TITLE
Fix Hazel build of uniplate

### DIFF
--- a/third_party/cabal2bazel/bzl/alex.bzl
+++ b/third_party/cabal2bazel/bzl/alex.bzl
@@ -30,7 +30,7 @@
 #   )
 def genalex(src, out):
   native.genrule(
-      name=src + ".hs_alex",
+      name=out + ".hs_alex",
       srcs=[src],
       outs=[out],
       tools=["@haskell_alex//:alex_bin"],

--- a/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -28,8 +28,10 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl", "haskell_library")
 def _impl_path_module_gen(ctx):
   paths_file = ctx.new_file(ctx.label.name)
 
-  base_dir = ctx.label.package + (
-      ("/" + ctx.attr.data_dir) if ctx.attr.data_dir else "")
+  base_dir = paths.join(
+      ctx.label.package,
+      ctx.attr.data_dir if ctx.attr.data_dir else ""
+  )
 
   ctx.template_action(
       template=ctx.file._template,

--- a/third_party/cabal2bazel/bzl/happy.bzl
+++ b/third_party/cabal2bazel/bzl/happy.bzl
@@ -31,7 +31,7 @@ Example:
 
 def genhappy(src, out):
   native.genrule(
-      name = src + ".hs_happy",
+      name = out + ".hs_happy",
       srcs = [src],
       outs = [out],
       tools = ["@haskell_happy//:happy_bin"],


### PR DESCRIPTION
Allows to build the `uniplate` library with Hazel.

* Keep the original source tree structure intact in the build tree.
    Previously, Hazel would link source files into the build tree under a path determined by their module path. This broke CPP include directives. Now source files are linked into the build tree under their original path.
* Add extra-source-files to the build tree
    Previously, files declared as `extra-source-files` would not be copied into the build tree, but only added in `-I` flags. This broke CPP include directives.
* Make chs targets depend on previous chs target, same as Cabal.
    Previously, chs modules were built in arbitrary order without dependency to any other chs targets. However, cabal builds chs modules in their order of appearance in the cabal file and later chs modules can depend on earlier ones.