### PR TITLE
Update rules_haskell

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -37,7 +37,7 @@ cc_configure_custom(
 )
 
 
-RULES_HASKELL_SHA = "edcd7c107d49ba69c96fe625161c42d4e5610d30"
+RULES_HASKELL_SHA = "8bc2b2c847c54f3d9f6bd5000f8deefa1cf4c995"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -489,6 +489,7 @@ def cabal_haskell_package(
         name = exe_name,
         srcs = select(srcs),
         deps = select(deps),
+        linkstatic = False,
         visibility = ["//visibility:public"],
         **attrs
     )


### PR DESCRIPTION
In order to include https://github.com/tweag/rules_haskell/pull/515 which enables forwarding flags to hsc2hs.

Note, rules_haskell switched to static linking by default:
https://github.com/tweag/rules_haskell/commit/e75b61dde53154444b4f42dda92e54d756430ace
This causes linker errors in the Hazel build of happy. Specifying dynamic linking resolves the issue.