### PR TITLE
 Forward C header dependencies

### DIFF
--- a/hazel.bzl
+++ b/hazel.bzl
@@ -41,6 +41,13 @@ haskell_import(
     package = "{pkg}",
     visibility = ["//visibility:public"],
 )
+# Cabal packages can depend on other Cabal package's cbits, for example for
+# CPP includes. To enable uniform handling we define a `-cbits` target for
+# every Hazel Haskell target. In case of core_libraries this is just a dummy.
+cc_import(
+    name = "{pkg}-cbits",
+    visibility = ["//visibility:public"],
+)
 """.format(pkg=ctx.attr.package))
 
 _core_library_repository = repository_rule(

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -71,6 +71,15 @@ def _fix_source_dirs(dirs):
   return [""]
 
 def _module_output(file, ending):
+  """Replace the input's ending by the ending for the generated output file.
+
+  Args:
+    file: Input file name.
+    ending: Input file ending.
+
+  Returns:
+    The output file with appropriate ending. E.g. `file.y --> file.hs`.
+  """
   out_extension = {
     "hs": "hs",
     "lhs": "lhs",
@@ -83,6 +92,20 @@ def _module_output(file, ending):
   return file[:-len(ending)] + out_extension
 
 def _find_module_by_ending(modulePath, ending, sourceDirs):
+  """Try to find a source file for the given modulePath with the given ending.
+
+  Checks for module source files in all given source directories.
+
+  Args:
+    modulePath: The module path converted to a relative file path. E.g.
+      `Some/Module/Name`
+    ending: Look for module source files with this file ending.
+    sourceDirs: Look for module source files in these directories.
+
+  Returns:
+    Either `None` if no source file was found, or a `struct` describing the
+    module source file. See `_find_module` for details.
+  """
   # Find module source file in source directories.
   files = native.glob([
     paths.join(d if d != "." else "", modulePath + "." + ending)
@@ -105,6 +128,23 @@ def _find_module_by_ending(modulePath, ending, sourceDirs):
   )
 
 def _find_module(module, sourceDirs):
+  """Find the source file for the given module.
+
+  Args:
+    module: Find the source file for this module. E.g. `Some.Module.Name`.
+    sourceDirs: List of source directories under which to search for sources.
+
+  Returns:
+    Either `None` if no module source file was found,
+    or a `struct` with the following fields:
+
+    `type`: The ending.
+    `src`: The source file that was found.
+      E.g. `Some/Module/Name.y`
+    `out`: The expected generated output module file.
+      E.g. `Some/Module/Name.hs`.
+    `bootFile`: Haskell boot file path or `None` if no boot file was found.
+  """
   modulePath = module.replace(".", "/")
   mod = None
   # Looking for raw source files first. To override duplicates (e.g. if a

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -262,7 +262,6 @@ def _get_build_attrs(
         if m in boot_module_map:
           srcs[condition] += [boot_module_map[m]]
       else:
-        # XXX: Redundant?
         fail("Missing module %s for %s" % (m, name) + str(module_map))
 
   # Collect the options to pass to ghc.

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -322,6 +322,11 @@ def _get_build_attrs(
   ghcopts += ["-w", "-Wwarn"]  # -w doesn't kill all warnings...
 
   # Collect the dependencies.
+  #
+  # If package A depends on packages B and C, then the cbits target A-cbits
+  # will depend on B-cbits and C-cbits, and the Haskell target A will depend on
+  # A-cbits and the Haskell targets B and C. This allows A-cbits to depend on
+  # header files in B-cbits and C-cbits, as is the case with Cabal.
   for condition, ps in _conditions_dict(depset(
       [p.name for p in build_info.targetBuildDepends]).to_list()).items():
     if condition not in deps:
@@ -329,7 +334,9 @@ def _get_build_attrs(
     if condition not in cdeps:
       cdeps[condition] = []
     for p in ps:
+      # Collect direct Haskell dependencies.
       deps[condition] += [hazel_library(p)]
+      # Collect direct cbits dependencies.
       cdeps[condition] += [hazel_cbits(p)]
       if p in _CORE_DEPENDENCY_INCLUDES:
         cdeps[condition] += [_CORE_DEPENDENCY_INCLUDES[p]]

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -131,7 +131,7 @@ def _find_module(module, sourceDirs):
   """Find the source file for the given module.
 
   Args:
-    module: Find the source file for this module. E.g. `Some.Module.Name`.
+    module: The Haskell module name. E.g. `Some.Module.Name`.
     sourceDirs: List of source directories under which to search for sources.
 
   Returns:

--- a/third_party/haskell/BUILD.conduit
+++ b/third_party/haskell/BUILD.conduit
@@ -31,3 +31,8 @@ haskell_library(
     hazel_library("vector"),
   ],
 )
+
+cc_import(
+    name = "conduit-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.text_metrics
+++ b/third_party/haskell/BUILD.text_metrics
@@ -15,3 +15,8 @@ haskell_library(
     hazel_library("vector"),
   ],
 )
+
+cc_import(
+    name = "text-metrics-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.vault
+++ b/third_party/haskell/BUILD.vault
@@ -30,3 +30,8 @@ haskell_library(
     hazel_library("unordered-containers"),
   ],
 )
+
+cc_import(
+    name = "vault-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.wai_app_static
+++ b/third_party/haskell/BUILD.wai_app_static
@@ -42,3 +42,8 @@ haskell_library(
   ],
   version = "3.1.6.2",
 )
+
+cc_import(
+    name = "wai-app-static-cbits",
+    visibility = ["//visibility:public"],
+)

--- a/third_party/haskell/BUILD.zlib
+++ b/third_party/haskell/BUILD.zlib
@@ -7,7 +7,7 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
 load("@ai_formation_hazel//:hazel.bzl", "hazel_library")
 
 cc_library(
-  name = "cbits",
+  name = "zlib-cbits",
   hdrs = glob(["cbits/*.h"]),
   srcs = glob(["cbits/*.c"]),
   strip_include_prefix = "cbits",
@@ -21,7 +21,7 @@ haskell_library(
     "Codec/Compression/Zlib/*.hsc",
   ]),
   deps = [
-      ":cbits",
+      ":zlib-cbits",
       hazel_library("base"),
       hazel_library("bytestring"),
       hazel_library("ghc-prim"),

--- a/tools/mangling.bzl
+++ b/tools/mangling.bzl
@@ -8,6 +8,11 @@ def hazel_binary(package_name):
   return "@{}//:{}_bin".format(hazel_workspace(package_name), package_name)
 
 
+def hazel_cbits(package_name):
+  """Returns the label of the cc_library rule for the given package."""
+  return "@{}//:{}-cbits".format(hazel_workspace(package_name), package_name)
+
+
 def hazel_workspace(package_name):
   """Convert a package name to a valid and unambiguous workspace name.
 


### PR DESCRIPTION
Cabal allows packages to use CPP `#include` on files from dependencies. E.g. if the Cabal package `proj-a` includes a file `header.h` (specified in `extra-source-files` and with appropriate `include-dirs`). Then another package `proj-b`, which depends on `proj-a`, can `#include "header.h"`. This is true between Cabal packages, as well as, between library and executable targets within a Cabal package.

Hazel, currently fails to build packages that exploit this feature. The reason is that header files and include dirs are captured in a `cbits` target, but only the current `haskell_library|binary` target depends on it. The `cbits` target is not forwarded to other Hazel targets.

This PR changes that. If a Hazel target `A` depends on a Hazel target `B`, then `A-cbits` will depend on `B-cbits`. Since `A` depends on `A-cbits`, `A` can now also depend on headers defined in `B-cbits`. Refer to https://github.com/tweag/rules_haskell/issues/531 for more details.
