### PR TITLE
Define *-cbits on empty libraries

### DIFF
--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -452,6 +452,10 @@ def cabal_haskell_package(
           name = name,
           visibility = ["//visibility:public"],
       )
+      native.cc_library(
+          name = name + "-cbits",
+          visibility = ["//visibility:public"],
+      )
     else:
       lib_attrs = _get_build_attrs(
         name,


### PR DESCRIPTION
If a Cabal library does not expose any modules, Hazel takes a short-cut and defines an empty cc_library target instead of building a haskell_library target. This mechanism had not been updated to also define a *-cbits target as is required since commit 7ffc6ec. This PR changes that.

This issue comes up on the bytestring-builder package. The bytestring-builder package defaults to an empty library, since recent versions of bytestring contain the bytestring-builder package.