### PR TITLE
Revert to default linkstatic

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,8 +36,7 @@ cc_configure_custom(
     ld = "@binutils//:bin/ld",
 )
 
-
-RULES_HASKELL_SHA = "8bc2b2c847c54f3d9f6bd5000f8deefa1cf4c995"
+RULES_HASKELL_SHA = "d2abf00e76fe055c19cdb35dc30c16478e06d072"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -531,7 +531,6 @@ def cabal_haskell_package(
         name = exe_name,
         srcs = select(srcs),
         deps = select(deps),
-        linkstatic = False,
         visibility = ["//visibility:public"],
         **attrs
     )


### PR DESCRIPTION
rules_haskell defaults to `linkstatic = False` on library targets and `True` on executable targets. Static linking was previously broken on core package dependencies and `cc_library` dependencies. However, this has been fixed in the latest rules_haskell revision.