### PR TITLE
Update to recent rules_haskell

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,9 @@ load("@io_tweag_rules_haskell//haskell:haskell.bzl",
   "haskell_toolchain",
   "haskell_doctest_toolchain",
 )
+load("@io_tweag_rules_haskell//haskell:c2hs.bzl",
+  "c2hs_toolchain",
+)
 load("//tools:mangling.bzl", "hazel_binary")
 
 exports_files([
@@ -14,6 +17,11 @@ exports_files([
 haskell_doctest_toolchain(
     name = "doctest",
     doctest = hazel_binary("doctest"),
+)
+
+c2hs_toolchain(
+    name = "c2hs-toolchain",
+    c2hs = "@c2hs//:bin",
 )
 
 cc_import(

--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -34,7 +34,7 @@ cc_library(
     # dependency of `libHSrts_thr_ghc*`
     # globbing on the `so` version to stay working when they update
     [
-        "lib/ghc-*/rts/libffi.so.*",
+        "lib/ghc-*/rts/libffi.so*",
     ],
   ),
   hdrs = glob(["lib/ghc-*/include/**/*.h"]),

--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -26,9 +26,22 @@ filegroup(
 
 cc_library(
   name = "threaded-rts",
-  srcs = glob(["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in ["so", "dylib"]]),
+  srcs = glob(
+    ["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in [
+        "so",
+        "dylib",
+    ]] +
+    # dependency of `libHSrts_thr_ghc*`
+    # globbing on the `so` version to stay working when they update
+    [
+        "lib/ghc-*/rts/libffi.so.*",
+    ],
+  ),
   hdrs = glob(["lib/ghc-*/include/**/*.h"]),
-  strip_include_prefix = glob(["lib/ghc-*/include"], exclude_directories=0)[0],
+  strip_include_prefix = glob(
+    ["lib/ghc-*/include"],
+    exclude_directories = 0,
+  )[0],
 )
 
 # TODO: detect this more automatically.
@@ -39,13 +52,7 @@ cc_library(
 )
 
 haskell_toolchain(
-    name = "ghc",
-    c2hs = "@c2hs//:bin",
-    version = "8.2.2",
-    tools = ":bin",
-    locale_archive = select({
-      # For some reason glibcLocales is not available on Darwin.
-      "@bazel_tools//src/conditions:darwin": None,
-      "//conditions:default": "@glib_locales//:locale-archive",
-    }),
+  name = "ghc",
+  version = "8.2.2",
+  tools = ":bin",
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -36,7 +36,7 @@ cc_configure_custom(
     ld = "@binutils//:bin/ld",
 )
 
-RULES_HASKELL_SHA = "d2abf00e76fe055c19cdb35dc30c16478e06d072"
+RULES_HASKELL_SHA = "869d14b8c7c95745b146be9ec15285d8c6dabe57"
 
 http_archive(
     name = "io_tweag_rules_haskell",

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -21,10 +21,12 @@ and {hash} is the Bazel hash of the original package name.
 """
 load("@bazel_skylib//:lib.bzl", "paths")
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
-     "c2hs_library",
      "haskell_library",
      "haskell_binary",
      "haskell_cc_import",
+)
+load("@io_tweag_rules_haskell//haskell:c2hs.bzl",
+     "c2hs_library",
 )
 load(":bzl/alex.bzl", "genalex")
 load(":bzl/cabal_paths.bzl", "cabal_paths")


### PR DESCRIPTION
Updates Hazel to work with rules_haskell as of 869d14b8c7c95745b146be9ec15285d8c6dabe57.

- Toolchain handling in rules_haskell was changed to accommodate Windows and non-nix platforms.
- The c2hs tool was separated into a dedicated toolchain.