### PR TITLE
Avoid linking to the threaded rts dylib

### DIFF
--- a/BUILD.ghc
+++ b/BUILD.ghc
@@ -25,6 +25,15 @@ filegroup(
 )
 
 cc_library(
+  name = "rts-headers",
+  hdrs = glob(["lib/ghc-*/include/**/*.h"]),
+  strip_include_prefix = glob(
+    ["lib/ghc-*/include"],
+    exclude_directories = 0,
+  )[0],
+)
+
+cc_library(
   name = "threaded-rts",
   srcs = glob(
     ["lib/ghc-*/rts/libHSrts_thr-ghc*." + ext for ext in [

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -395,7 +395,7 @@ def _get_build_attrs(
                  ]),
       defines = [o[2:] for o in build_info.ccOptions if o.startswith("-D")],
       textual_hdrs = list(headers),
-      deps = ["{}//:threaded-rts".format(ghc_workspace)] + select(cdeps) + cc_deps + elibs_targets,
+      deps = ["{}//:rts-headers".format(ghc_workspace)] + select(cdeps) + cc_deps + elibs_targets,
       visibility = ["//visibility:public"],
   )
 


### PR DESCRIPTION
With https://github.com/tweag/rules_haskell/pull/663 rules_haskell handles transitive C library dependencies (indirect through other cc_library targets).

Hazel always linked to the threaded GHC rts library. With the above PR this causes every Hazel target to depend on the threaded rts. This can cause conflicts if GHC also links against the non-threaded rts, which can cause segfaults at execution.

This commit works around this by only depending on the rts headers.