### PR TITLE
Add stdc++ to ignored CXX extra libraries

### DIFF
--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -20,7 +20,7 @@ where {package} is the lower-cased package name with - replaced by _
 and {hash} is the Bazel hash of the original package name.
 """
 load("@bazel_skylib//:lib.bzl", "paths")
-load("@bazel_skylib//:lib.bzl", "new_sets")
+load("@bazel_skylib//:lib.bzl", sets="new_sets")
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
      "haskell_binary",
@@ -37,9 +37,7 @@ load("//tools:mangling.bzl", "hazel_cbits", "hazel_library")
 
 _conditions_default = "//conditions:default"
 
-sets = new_sets
-
-# Those libraries are already provided by Bazel for all C++ targets,
+# Those libraries are already provided by Bazel or rules_haskell,
 # and must thus be ignored when specified as extra libraries.
 _excluded_cxx_libs = sets.make(elements = ["pthread", "stdc++"])
 

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -20,6 +20,7 @@ where {package} is the lower-cased package name with - replaced by _
 and {hash} is the Bazel hash of the original package name.
 """
 load("@bazel_skylib//:lib.bzl", "paths")
+load("@bazel_skylib//:lib.bzl", "new_sets")
 load("@io_tweag_rules_haskell//haskell:haskell.bzl",
      "haskell_library",
      "haskell_binary",
@@ -35,6 +36,12 @@ load("//templates:templates.bzl", "templates")
 load("//tools:mangling.bzl", "hazel_cbits", "hazel_library")
 
 _conditions_default = "//conditions:default"
+
+sets = new_sets
+
+# Those libraries are already provided by Bazel for all C++ targets,
+# and must thus be ignored when specified as extra libraries.
+_excluded_cxx_libs = sets.make(elements = ["pthread", "stdc++"])
 
 def _get_core_dependency_includes(ghc_workspace):
   """Include files that are exported by core dependencies
@@ -239,7 +246,7 @@ def _get_build_attrs(
         deps = [
           extra_libs[elib]
           for elib in build_info.extraLibs
-          if elib != "pthread"
+          if not sets.contains(_excluded_cxx_libs, elib)
         ] + [clib_name] + chs_targets,
       )
       chs_targets.append(chs_name)
@@ -376,7 +383,7 @@ def _get_build_attrs(
   elibs_targets = [
     extra_libs[elib]
     for elib in build_info.extraLibs
-    if elib != "pthread"
+    if not sets.contains(_excluded_cxx_libs, elib)
   ]
 
   native.cc_library(
@@ -480,7 +487,7 @@ def cabal_haskell_package(
       elibs_targets = [
         extra_libs[elib]
         for elib in lib.libBuildInfo.extraLibs
-        if elib != "pthread"
+        if not sets.contains(_excluded_cxx_libs, elib)
       ]
 
       hidden_modules = [m for m in lib.libBuildInfo.otherModules if not m.startswith("Paths_")]


### PR DESCRIPTION
This is required, for example, for the `re2` package to build, as it explicitly specifies `stdc++`.