### PR TITLE
Clarify version errors, generate paths in subdir

### DIFF
--- a/hazel_base_repository/hazel_base_repository.bzl
+++ b/hazel_base_repository/hazel_base_repository.bzl
@@ -63,7 +63,16 @@ def symlink_and_invoke_hazel(ctx, hazel_base_repo_name, ghc_workspace, package_f
   for f in [cabal2bazel, "ghc-version"]:
     ctx.symlink(Label("@" + hazel_base_repo_name + "//:" + f), f)
 
-  ghc_version = ctx.execute(["cat", "ghc-version"]).stdout
+  cat_ghc_version = ctx.execute(["cat", "ghc-version"])
+
+  if cat_ghc_version.return_code != 0:
+    fail("Could not read ghc-version, got return code {}, stderr: {}, stdout: {}".format(
+            cat_ghc_version.return_code,
+            cat_ghc_version.stderr,
+            cat_ghc_version.stdout,
+            ))
+
+  ghc_version = cat_ghc_version.stdout
 
   flag_args = []
 

--- a/third_party/cabal2bazel/bzl/cabal_package.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_package.bzl
@@ -373,6 +373,9 @@ def _get_build_attrs(
     xs.append(":" + clib_name)
 
   ghc_version_components = ghc_version.split(".")
+  if len(ghc_version_components) != 3:
+      fail("Not enough version components for GHC:" + str(ghc_version_components))
+
   ghc_version_string = (
       ghc_version_components[0] +
       ("0" if int(ghc_version_components[1]) <= 9 else "")

--- a/third_party/cabal2bazel/bzl/cabal_paths.bzl
+++ b/third_party/cabal2bazel/bzl/cabal_paths.bzl
@@ -97,7 +97,12 @@ def cabal_paths(name=None, package=None, data_dir='',data=[], version=[], **kwar
     version: The version number of this package (list of ints)
   """
   module_name = "Paths_" + package
-  paths_file = module_name + ".hs"
+  # XXX: we generate the `Paths_` file in a different directory otherwise GHC
+  # picks up on it when building the actual target (because no sandbox on
+  # Windows) and crashes (the actual target may not have the same set of
+  # dependencies as Paths_)
+  # TODO: 'gen_paths' may clash with other dirs!
+  paths_file = "gen_paths/" + module_name + ".hs"
   _path_module_gen(
       name = paths_file,
       module=module_name,


### PR DESCRIPTION
Quote from the code:

```
  # XXX: we generate the `Paths_` file in a different directory otherwise GHC
  # picks up on it when building the actual target (because no sandbox on
  # Windows) and crashes (the actual target may not have the same set of
  # dependencies as Paths_)
  # TODO: 'gen_paths' may clash with other dirs!
```