### PR TITLE
Improve package names

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,22 +101,21 @@ and construct build rules for compiling the components of that package.
 
 Note, that Haskell package names are case-sensitive while Bazel workspace names
 are case-insensitive on case-insensitive file systems. For the generated
-workspace names to be case-insensitive we include a hash of the original
-package name. Query for targets `@all_hazel_packages//:haskell_{package_name}`
-to determine the generated workspace name.
+workspace names to be case-insensitive we perform a substitution on some
+characters. An upper case character is converted to its lowercase equivalent
+followed by an underscore. A hyphen is converted to two underscores. Digits and
+lowercase characters and left as-is.
 
-For example:
 
-```
-# Discover the generated external workspace for the vector package.
-bazel query 'deps(@all_hazel_packages//:haskell_vector, 1)'
-# --> @haskell_vector__820387517//:bzl
-
-# Build all components of a single package, as well as all of its dependencies:
-bazel build @haskell_vector__820387517//:all
-
-# Build all components of all third-party packages:
-bazel build @all_hazel_packages//:all
+``` python
+  >>> case_insensitive_name("Cabal")
+  'c_abal'
+  >>> case_insensitive_name("conduit")
+  'conduit'
+  >>> case_insensitive_name("AERN-Net")
+  'a_e_r_n___n_et'
+  >>> case_insensitive_name("c2hs-extra")
+  'c2hs__extra'
 ```
 
 To depend on a third-party package in a `BUILD` file, use the macros provided by `hazel.bzl`:

--- a/tools/mangling.bzl
+++ b/tools/mangling.bzl
@@ -46,9 +46,21 @@ def fixup_package_name(package_name):
 def case_insensitive_name(package_name):
   """Convert a package name to a case-insensitive name.
 
-  Appends the hash of the input string, and converts the whole string to
-  lower case. Note, the appended hash value is represented in decimal, and
-  may be negative.
+  An upper case character is converted to its lowercase equivalent followed by
+  an underscore.
+
+  A hyphen is converted to two underscores.
+
+  A digits and lowercase characters and left as-is.
+
+  >>> case_insensitive_name("Cabal")
+  'c_abal'
+  >>> case_insensitive_name("conduit")
+  'conduit'
+  >>> case_insensitive_name("AERN-Net")
+  'a_e_r_n___n_et'
+  >>> case_insensitive_name("c2hs-extra")
+  'c2hs__extra'
 
   Args:
     name: string: A potentially case-sensitive package name.
@@ -56,7 +68,18 @@ def case_insensitive_name(package_name):
   Returns:
     string: A case-insensitive package name.
   """
-  return "{lower}_{hash}".format(
-    lower = package_name.lower(),
-    hash = hash(package_name)
-  )
+
+  chars = package_name.elems()
+  out = []
+
+  for c in chars:
+      if c.islower() or c.isdigit():
+          out += [c]
+      elif c.isupper():
+          out += [c.lower(), '_']
+      elif c == '-':
+          out += ['_', '_']
+      else:
+          fail("Don't know how to handle char %s in %s" % ([c], package_name))
+
+  return ''.join(out)

--- a/tools/mangling.bzl
+++ b/tools/mangling.bzl
@@ -51,7 +51,7 @@ def case_insensitive_name(package_name):
 
   A hyphen is converted to two underscores.
 
-  A digits and lowercase characters and left as-is.
+  Digits and lowercase characters and left as-is.
 
   >>> case_insensitive_name("Cabal")
   'c_abal'


### PR DESCRIPTION
E.g.:

``` python
  >>> case_insensitive_name("Cabal")
  'c_abal'
  >>> case_insensitive_name("conduit")
  'conduit'
  >>> case_insensitive_name("AERN-Net")
  'a_e_r_n___n_et'
  >>> case_insensitive_name("c2hs-extra")
  'c2hs__extra'
```